### PR TITLE
add options for default question and votes

### DIFF
--- a/app.py
+++ b/app.py
@@ -35,6 +35,10 @@ if not hasattr(settings, 'BARS_BY_DEFAULT'):
     settings.BARS_BY_DEFAULT = True
 if not hasattr(settings, 'BAR_IMG_URL'):
     settings.BAR_IMG_URL = None
+if not hasattr(settings, 'DEFAULT_QUESTION'):
+    settings.DEFAULT_QUESTION = None
+if not hasattr(settings, 'DEFAULT_VOTES'):
+    settings.DEFAULT_VOTES = []
 
 
 def parse_slash_command(command):
@@ -55,8 +59,12 @@ def parse_slash_command(command):
         - locale: str
     """
     args = [arg.strip() for arg in command.split('--')]
-    message = args[0]
-    vote_options = []
+    if not args[0]:
+        message = settings.DEFAULT_QUESTION
+        vote_options = settings.DEFAULT_VOTES
+    else:
+        message = args[0]
+        vote_options = []
     progress = settings.PROGRESS_BY_DEFAULT
     public = settings.PUBLIC_BY_DEFAULT
     bars = settings.BARS_BY_DEFAULT

--- a/app.py
+++ b/app.py
@@ -36,7 +36,7 @@ if not hasattr(settings, 'BARS_BY_DEFAULT'):
 if not hasattr(settings, 'BAR_IMG_URL'):
     settings.BAR_IMG_URL = None
 if not hasattr(settings, 'DEFAULT_QUESTION'):
-    settings.DEFAULT_QUESTION = None
+    settings.DEFAULT_QUESTION = ''
 if not hasattr(settings, 'DEFAULT_VOTES'):
     settings.DEFAULT_VOTES = []
 

--- a/settings.py.example
+++ b/settings.py.example
@@ -31,6 +31,12 @@ PUBLIC_BY_DEFAULT = False
 PROGRESS_BY_DEFAULT = True
 BARS_BY_DEFAULT = True
 
+# Set default question and vote possibilities, if the user does not provide
+# any of those (i.e., if the user just writes the slash command).
+# If these options are not set, the default behavior is to show the help message.
+# DEFAULT_QUESTION = "What is your favorite color?"
+# DEFAULT_VOTES = ["Green", "Blue", "Red"]
+
 # Uncomment the following lines to enable file logging:
 #import logging
 #logging.basicConfig(filename='poll.log', level=logging.DEBUG)


### PR DESCRIPTION
These options become useful, if you most of the time need the same poll. If the user does only write the slash command, the default question and votes are automatically filled in. If the options are not used (default), then the behavior as it is now is preserved: With no additional command, an empty slash command returns the help message.